### PR TITLE
Fix Updater quotes

### DIFF
--- a/Updater.ps1
+++ b/Updater.ps1
@@ -208,7 +208,7 @@ Function Updater {
 Function InternetConnectivityCheck {
 
 # Internet Connectivity Check (Vista+)
-$NetworkListManager = [Activator]::CreateInstance([Type]::GetTypeFromCLSID([Guid]‘{DCB00C01-570F-4A9B-8D69-199FDBA5723B}’)).IsConnectedToInternet
+$NetworkListManager = [Activator]::CreateInstance([Type]::GetTypeFromCLSID([Guid]'{DCB00C01-570F-4A9B-8D69-199FDBA5723B}')).IsConnectedToInternet
 
 # Offline
 if (!($NetworkListManager -eq "True"))
@@ -453,7 +453,7 @@ if (!(Test-Path "C:\Program Files\ClamAV\clamd.conf"))
 if (Test-Path "$($freshclam)")
 {
     # Internet Connectivity Check (Vista+)
-    $NetworkListManager = [Activator]::CreateInstance([Type]::GetTypeFromCLSID([Guid]‘{DCB00C01-570F-4A9B-8D69-199FDBA5723B}’)).IsConnectedToInternet
+    $NetworkListManager = [Activator]::CreateInstance([Type]::GetTypeFromCLSID([Guid]'{DCB00C01-570F-4A9B-8D69-199FDBA5723B}')).IsConnectedToInternet
 
     if (!($NetworkListManager -eq "True"))
     {


### PR DESCRIPTION
When attempting to execute the "Updater.ps1" script via PowerShell command line and via Command Prompt (powershell -c), the Updater script fails due to unrecognized characters surrounding the `Guid` values at [Line 211](https://github.com/LETHAL-FORENSICS/MemProcFS-Analyzer/blob/bc05672a303de06a98db23a9388cecf93ce7ff63/Updater.ps1#L211) and [Line 456](https://github.com/LETHAL-FORENSICS/MemProcFS-Analyzer/blob/bc05672a303de06a98db23a9388cecf93ce7ff63/Updater.ps1#L456).

Replacing these with a single (non-smart) quote resolves the issue.