### PR TITLE
Set default for basic parsing

### DIFF
--- a/Updater.ps1
+++ b/Updater.ps1
@@ -74,6 +74,9 @@
 $OriginalProgressPreference = $Global:ProgressPreference
 $Global:ProgressPreference = 'SilentlyContinue'
 
+# Set Invoke-WebRequest Preference to UseBasicParsing
+$PSDefaultParameterValues['Invoke-WebRequest:UseBasicParsing'] = $true
+
 #endregion Initialisations
 
 #############################################################################################################################################################################################


### PR DESCRIPTION
During each run of the Updater.ps1 script, the following warning is presented:
```
Security Warning: Script Execution Risk
Invoke-WebRequest parses the content of the web page. Script code in the web page might be run when the page is parsed.
      RECOMMENDED ACTION:
      Use the -UseBasicParsing switch to avoid script code execution.

      Do you want to continue?

[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "N"):
```

This message pops up because the Invoke-WebRequests being used to download the files do not have `-UseBasicParsing` set as an option, though others ($Headers, $Response) do. Since the purpose of these IWR's is simply to download files, it makes sense to set this as a default option. Adding it as one line instead of modifying every line simply reduces effort and code.